### PR TITLE
Replace JSON.stringify with util.inspect

### DIFF
--- a/src/device-lister.js
+++ b/src/device-lister.js
@@ -115,7 +115,7 @@ export default class DeviceLister extends EventEmitter {
             results.forEach(trait => {
                 let { serialNumber } = trait;
                 if (trait.error || (!serialNumber)) {
-                    const hash = JSON.stringify(trait);
+                    const hash = inspect(trait, { depth: null });
                     if (!this._currentErrors.has(hash)) {
                         const capName = Object.keys(trait).filter(key => key !== 'error' && key !== 'serialNumber')[0];
                         if (trait.error) {


### PR DESCRIPTION
This fixes an error case when an error from the USB backend includes a reference to a USB `Device` which is *open* (i.e. a error during closing of the `Device` because of race conditions). Replacing `JSON.stringify()` with `util.inspect()` does the same job (provide a serialized representation of the device), but gets rid of the circular references without throwing errors.

Covers the error described in #11.