### PR TITLE
Add a 'nordic-dfu-trigger' backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ var lister = new DeviceLister({
     usb: true,
     nordicUsb: false,   // Like 'usb', but filters by VendorId
     seggerUsb: false,   // Like 'usb', but filters by VendorId
+    nordicDfu: false,   // Like 'nordicUsb', but also looks for the Nordic DFU trigger interface
     serialport: true,
     jlink: true,
 });
@@ -54,6 +55,18 @@ lister.on('conflated', function(deviceMap){
        { error: undefined,
          serialNumber: 12345678,
          usb: { serialNumber: 12345678,
+                 manufacturer: "Manufacturer Co",
+                 product: "Gizmo",
+                 device: (Instance of Device as per 'usb' module) }
+         nordicUsb: { serialNumber: 12345678,
+                 manufacturer: "Manufacturer Co",
+                 product: "Gizmo",
+                 device: (Instance of Device as per 'usb' module) }
+         seggerUsb: { serialNumber: 12345678,
+                 manufacturer: "Manufacturer Co",
+                 product: "Gizmo",
+                 device: (Instance of Device as per 'usb' module) }
+         nordicDfu: { serialNumber: 12345678,
                  manufacturer: "Manufacturer Co",
                  product: "Gizmo",
                  device: (Instance of Device as per 'usb' module) }

--- a/bin/device-lister.js
+++ b/bin/device-lister.js
@@ -43,6 +43,7 @@ args
     .description('List conflated USB/serialport/jlink devices')
     .option('-u, --usb', 'Include USB devices (those available through libusb)')
     .option('-n, --nordic-usb', 'Include Nordic USB devices (with VendorID 0x1915, if available through libusb)')
+    .option('-f, --nordic-dfu', 'Include Nordic USB devices with DFU sidechannel')
     .option('-g, --segger-usb', 'Include Segger USB devices (with VendorID 0x1366, if available through libusb)')
     .option('-s, --serialport', 'Include serial ports (including USB CDC ACMs)')
     .option('-j, --jlink', 'Include J-link probes (those available through pc-nrfjprog-js)')
@@ -54,7 +55,7 @@ if (args.debug) {
     debug.enable('device-lister:*');
 }
 
-if (!args.usb && !args.nordicUsb && !args.seggerUsb && !args.serialport && !args.jlink) {
+if (!args.usb && !args.nordicUsb && !args.nordicDfu && !args.seggerUsb && !args.serialport && !args.jlink) {
     console.error('No device capabilties specified, no devices will be listed!');
     console.error('Run with the --help option to see types of devices to watch for.');
 }
@@ -62,6 +63,7 @@ if (!args.usb && !args.nordicUsb && !args.seggerUsb && !args.serialport && !args
 const lister = new DeviceLister({
     usb: args.usb,
     nordicUsb: args.nordicUsb,
+    nordicDfu: args.nordicDfu,
     seggerUsb: args.seggerUsb,
     serialport: args.serialport,
     jlink: args.jlink,

--- a/bin/device-lister.js
+++ b/bin/device-lister.js
@@ -55,7 +55,8 @@ if (args.debug) {
     debug.enable('device-lister:*');
 }
 
-if (!args.usb && !args.nordicUsb && !args.nordicDfu && !args.seggerUsb && !args.serialport && !args.jlink) {
+if (!args.usb && !args.nordicUsb && !args.nordicDfu && !args.seggerUsb &&
+    !args.serialport && !args.jlink) {
     console.error('No device traits specified, no devices will be listed!');
     console.error('Run with the --help option to see types of devices to watch for.');
 }

--- a/bin/device-lister.js
+++ b/bin/device-lister.js
@@ -43,7 +43,7 @@ args
     .description('List conflated USB/serialport/jlink devices')
     .option('-u, --usb', 'Include USB devices (those available through libusb)')
     .option('-n, --nordic-usb', 'Include Nordic USB devices (with VendorID 0x1915, if available through libusb)')
-    .option('-f, --nordic-dfu', 'Include Nordic USB devices with DFU sidechannel')
+    .option('-f, --nordic-dfu', 'Include Nordic USB devices with DFU trigger interface')
     .option('-g, --segger-usb', 'Include Segger USB devices (with VendorID 0x1366, if available through libusb)')
     .option('-s, --serialport', 'Include serial ports (including USB CDC ACMs)')
     .option('-j, --jlink', 'Include J-link probes (those available through pc-nrfjprog-js)')

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "rollup": "rollup -c rollup.config.js",
-    "lint": "eslint src/",
-    "lintfix": "eslint src/ --fix"
+    "lint": "eslint src/ bin/",
+    "lintfix": "eslint src/ bin/ --fix"
   },
   "files": [
     "bin/",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,6 +9,7 @@ export default [
             // { file: pkg.module, format: 'es', sourcemap: true }
         ],
         external: [
+            'await-semaphore',
             'events',
             'util',
             'debug',

--- a/src/device-lister.js
+++ b/src/device-lister.js
@@ -34,7 +34,7 @@ import Usb from 'usb';
 import Debug from 'debug';
 import { inspect } from 'util';
 
-import { reenumerateUsb, reenumerateSeggerUsb, reenumerateNordicUsb, reenumerateNordicDfuSidechannel } from './usb-backend';
+import { reenumerateUsb, reenumerateSeggerUsb, reenumerateNordicUsb, reenumerateNordicDfuTrigger } from './usb-backend';
 import reenumerateSerialPort from './serialport-backend';
 import reenumerateJlink from './jlink-backend';
 
@@ -57,7 +57,7 @@ export default class DeviceLister extends EventEmitter {
 
         if (usb) { this._backends.push(reenumerateUsb); }
         if (nordicUsb) { this._backends.push(reenumerateNordicUsb); }
-        if (nordicDfu) { this._backends.push(reenumerateNordicDfuSidechannel); }
+        if (nordicDfu) { this._backends.push(reenumerateNordicDfuTrigger); }
         if (seggerUsb) { this._backends.push(reenumerateSeggerUsb); }
         if (serialport) { this._backends.push(reenumerateSerialPort); }
         if (jlink) { this._backends.push(reenumerateJlink); }

--- a/src/device-lister.js
+++ b/src/device-lister.js
@@ -33,7 +33,7 @@ import EventEmitter from 'events';
 import Usb from 'usb';
 import Debug from 'debug';
 
-import { reenumerateUsb, reenumerateSeggerUsb, reenumerateNordicUsb } from './usb-backend';
+import { reenumerateUsb, reenumerateSeggerUsb, reenumerateNordicUsb, reenumerateNordicDfuSidechannel } from './usb-backend';
 import reenumerateSerialPort from './serialport-backend';
 import reenumerateJlink from './jlink-backend';
 
@@ -51,11 +51,12 @@ export default class DeviceLister extends EventEmitter {
         this._backends = [];
 
         const {
-            usb, nordicUsb, seggerUsb, jlink, serialport,
+            usb, nordicUsb, nordicDfu, seggerUsb, jlink, serialport,
         } = capabilities;
 
         if (usb) { this._backends.push(reenumerateUsb); }
         if (nordicUsb) { this._backends.push(reenumerateNordicUsb); }
+        if (nordicDfu) { this._backends.push(reenumerateNordicDfuSidechannel); }
         if (seggerUsb) { this._backends.push(reenumerateSeggerUsb); }
         if (serialport) { this._backends.push(reenumerateSerialPort); }
         if (jlink) { this._backends.push(reenumerateJlink); }

--- a/src/usb-backend.js
+++ b/src/usb-backend.js
@@ -58,6 +58,8 @@ function hexpad4(number) {
 
 
 /*
+ * Given a filter function, and a trait name, returns a closure over a function that:
+ *
  * Given an instance of a USB device, returns *one* structure like:
  * {
  *   error: undefined
@@ -72,63 +74,74 @@ function hexpad4(number) {
  *
  * If there was an error fetching information, the serialNumber, manufacturer and
  * product fields will be empty, and the error field will contain the error.
+ *
+ * If the device didn't pass the `deviceFilter`, the closure function will return
+ * undefined instead.
  */
-function normalizeUsbDevice(usbDevice) {
-    const result = {
-        error: undefined,
-        serialNumber: undefined,
-        usb: {
+function normalizeUsbDeviceClosure(deviceFilter, traitName) {
+    return function normalizeUsbDevice(usbDevice) {
+        let result = {
+            error: undefined,
             serialNumber: undefined,
-            manufacturer: undefined,
-            product: undefined,
-            device: usbDevice,
-        },
-    };
+            [traitName]: {
+                serialNumber: undefined,
+                manufacturer: undefined,
+                product: undefined,
+                device: usbDevice,
+            },
+        };
 
-    const { busNumber, deviceAddress, deviceDescriptor } = usbDevice;
-    const {
-        iSerialNumber, iManufacturer, iProduct, idVendor, idProduct,
-    } = deviceDescriptor;
-    const debugIdStr = `${busNumber}.${deviceAddress} ${hexpad4(idVendor)}/${hexpad4(idProduct)}`;
+        const { busNumber, deviceAddress, deviceDescriptor } = usbDevice;
+        const {
+            iSerialNumber, iManufacturer, iProduct, idVendor, idProduct,
+        } = deviceDescriptor;
+        const debugIdStr = `${busNumber}.${deviceAddress} ${hexpad4(idVendor)}/${hexpad4(idProduct)}`;
 
-    return new Promise((res, rej) => {
-        try {
-            usbDevice.open();
-        } catch (ex) {
-            return rej(ex);
-        }
-        return res();
-    }).then(() => {
-        debug(`Opened: ${debugIdStr}`);
-
-        return Promise.all([
-            getStr(usbDevice, iSerialNumber),
-            getStr(usbDevice, iManufacturer),
-            getStr(usbDevice, iProduct),
-        ]);
-    }).then(([serialNumber, manufacturer, product]) => {
-        debug(`Enumerated: ${debugIdStr} `, [serialNumber, manufacturer, product]);
-        usbDevice.close();
-
-        result.serialNumber = serialNumber;
-        result.usb.serialNumber = serialNumber;
-        result.usb.manufacturer = manufacturer;
-        result.usb.product = product;
-        return result;
-    }).catch(ex => {
-        debug(`Error! ${debugIdStr}`, ex.message);
-
-        result.error = ex;
-    })
-        .then(() => {
-        // Clean up
+        return new Promise((res, rej) => {
             try {
-                usbDevice.close();
+                usbDevice.open();
             } catch (ex) {
-                debug(`Error! ${debugIdStr}`, ex.message);
+                return rej(ex);
             }
+            return res();
+        }).then(() => {
+            debug(`Opened: ${debugIdStr}`);
+
+            return Promise.all([
+                getStr(usbDevice, iSerialNumber),
+                getStr(usbDevice, iManufacturer),
+                getStr(usbDevice, iProduct),
+                deviceFilter(usbDevice),
+            ]);
+        }).then(([serialNumber, manufacturer, product, filtered]) => {
+            debug(`Enumerated: ${debugIdStr} `, [serialNumber, manufacturer, product]);
+            usbDevice.close();
+
+            if (filtered) {
+                result.serialNumber = serialNumber;
+                result[traitName].serialNumber = serialNumber;
+                result[traitName].manufacturer = manufacturer;
+                result[traitName].product = product;
+            } else {
+                debug(`Device ${debugIdStr} didn't pass the filter`);
+                result = undefined;
+            }
+            return result;
+        }).catch(ex => {
+            debug(`Error! ${debugIdStr}`, ex.message);
+
+            result.error = ex;
         })
-        .then(() => result);
+            .then(() => {
+            // Clean up
+                try {
+                    usbDevice.close();
+                } catch (ex) {
+                    debug(`Error! ${debugIdStr}`, ex.message);
+                }
+            })
+            .then(() => result);
+    };
 }
 
 /* Returns a Promise to a list of objects, like:
@@ -147,30 +160,55 @@ function normalizeUsbDevice(usbDevice) {
  * If there was an error fetching information, the serialNumber, manufacturer and
  * product fields will be empty, and the error field will contain the error.
  *
- * In the USB backend, errors are per-device.
- *
+ * In any USB backend, errors are per-device.
  */
-export function reenumerateUsb() {
-    debug('Reenumerating all USB devices...');
-    const usbDevices = Usb.getDeviceList();
-
-    return Promise.all(usbDevices.map(normalizeUsbDevice));
+function genericReenumerateUsb(
+    closedDeviceFilter = () => true, // Applies to *closed* instances of usb's Device
+    openedDeviceFilter = () => true, // Applies to *opened* instances of usb's Device
+    traitName = 'usb'
+) {
+    const usbDevices = Usb.getDeviceList().filter(closedDeviceFilter);
+    return Promise.all(usbDevices
+        .map(normalizeUsbDeviceClosure(openedDeviceFilter, traitName)))
+        .then(items => items.filter(item => item));
 }
 
+
+export function reenumerateUsb() {
+    debug('Reenumerating all USB devices...');
+    return genericReenumerateUsb(() => true, () => true, 'usb');
+}
+
+
 // Like reenumerateUsb, but cares only about USB devices with the Segger VendorId (0x1366)
+function filterSeggerVendorId(device) {
+    return device.deviceDescriptor.idVendor === SEGGER_VENDOR_ID;
+}
 export function reenumerateSeggerUsb() {
     debug('Reenumerating all Segger USB devices...');
-    const usbDevices = Usb.getDeviceList().filter(device =>
-        device.deviceDescriptor.idVendor === SEGGER_VENDOR_ID);
+    return genericReenumerateUsb(filterSeggerVendorId, () => true, 'usb');
+}
 
-    return Promise.all(usbDevices.map(normalizeUsbDevice));
+
+// Like reenumerateUsb, but cares only about USB devices with the Nordic VendorId (0x1915)
+function filterNordicVendorId(device) {
+    return device.deviceDescriptor.idVendor === NORDIC_VENDOR_ID;
+}
+export function reenumerateNordicUsb() {
+    debug('Reenumerating all Nordic USB devices...');
+    return genericReenumerateUsb(filterNordicVendorId, () => true, 'usb');
 }
 
 // Like reenumerateUsb, but cares only about USB devices with the Nordic VendorId (0x1915)
-export function reenumerateNordicUsb() {
-    debug('Reenumerating all Nordic USB devices...');
-    const usbDevices = Usb.getDeviceList().filter(device =>
-        device.deviceDescriptor.idVendor === NORDIC_VENDOR_ID);
-
-    return Promise.all(usbDevices.map(normalizeUsbDevice));
+// and a DFU sidechannel trigger interface
+function filterDfuSidechannel(device) {
+    return device.interfaces.some(iface => (
+        iface.descriptor.bInterfaceClass === 255 &&
+            iface.descriptor.bInterfaceSubClass === 1 &&
+            iface.descriptor.bInterfaceProtocol === 1
+    ));
+}
+export function reenumerateNordicDfuSidechannel() {
+    debug('Reenumerating all Nordic USB devices with DFU sidechannel trigger...');
+    return genericReenumerateUsb(filterNordicVendorId, filterDfuSidechannel, 'nordic-dfu-trigger');
 }

--- a/src/usb-backend.js
+++ b/src/usb-backend.js
@@ -97,7 +97,7 @@ function hexpad4(number) {
  * {
  *   error: undefined
  *   serialNumber: 1234,
- *   usb: {
+ *   [traitName]: {
  *     serialNumber: 1234,
  *     manufacturer: 'ACME',
  *     product: 'Sprocket adaptor'
@@ -149,9 +149,9 @@ function normalizeUsbDeviceClosure(deviceFilter, traitName) {
                     ]).then(([serialNumber, manufacturer, product]) => {
                         debug(`Enumerated: ${debugIdStr} `, [serialNumber, manufacturer, product]);
                         result.serialNumber = serialNumber;
-                        result.usb.serialNumber = serialNumber;
-                        result.usb.manufacturer = manufacturer;
-                        result.usb.product = product;
+                        result[traitName].serialNumber = serialNumber;
+                        result[traitName].manufacturer = manufacturer;
+                        result[traitName].product = product;
                     });
                 }
                 debug(`Device ${debugIdStr} didn't pass the filter`);
@@ -175,7 +175,8 @@ function normalizeUsbDeviceClosure(deviceFilter, traitName) {
     };
 }
 
-/* Returns a Promise to a list of objects, like:
+/*
+ * Given filters, and a trait name, returns a Promise to a list of objects, like:
  *
  * [{
  *   error: undefined
@@ -217,7 +218,7 @@ function filterSeggerVendorId(device) {
 }
 export function reenumerateSeggerUsb() {
     debug('Reenumerating all Segger USB devices...');
-    return genericReenumerateUsb(filterSeggerVendorId, () => true, 'usb');
+    return genericReenumerateUsb(filterSeggerVendorId, () => true, 'seggerUsb');
 }
 
 
@@ -227,7 +228,7 @@ function filterNordicVendorId(device) {
 }
 export function reenumerateNordicUsb() {
     debug('Reenumerating all Nordic USB devices...');
-    return genericReenumerateUsb(filterNordicVendorId, () => true, 'usb');
+    return genericReenumerateUsb(filterNordicVendorId, () => true, 'nordicUsb');
 }
 
 // Like reenumerateUsb, but cares only about USB devices with the Nordic VendorId (0x1915)
@@ -241,5 +242,5 @@ function filterDfuTrigger(device) {
 }
 export function reenumerateNordicDfuTrigger() {
     debug('Reenumerating all Nordic USB devices with DFU trigger interface...');
-    return genericReenumerateUsb(filterNordicVendorId, filterDfuTrigger, 'nordic-dfu-trigger');
+    return genericReenumerateUsb(filterNordicVendorId, filterDfuTrigger, 'nordicDfu');
 }

--- a/src/usb-backend.js
+++ b/src/usb-backend.js
@@ -231,15 +231,15 @@ export function reenumerateNordicUsb() {
 }
 
 // Like reenumerateUsb, but cares only about USB devices with the Nordic VendorId (0x1915)
-// and a DFU sidechannel trigger interface
-function filterDfuSidechannel(device) {
+// and a DFU trigger interface
+function filterDfuTrigger(device) {
     return device.interfaces.some(iface => (
         iface.descriptor.bInterfaceClass === 255 &&
             iface.descriptor.bInterfaceSubClass === 1 &&
             iface.descriptor.bInterfaceProtocol === 1
     ));
 }
-export function reenumerateNordicDfuSidechannel() {
-    debug('Reenumerating all Nordic USB devices with DFU sidechannel trigger...');
-    return genericReenumerateUsb(filterNordicVendorId, filterDfuSidechannel, 'nordic-dfu-trigger');
+export function reenumerateNordicDfuTrigger() {
+    debug('Reenumerating all Nordic USB devices with DFU trigger interface...');
+    return genericReenumerateUsb(filterNordicVendorId, filterDfuTrigger, 'nordic-dfu-trigger');
 }


### PR DESCRIPTION
Alternative to #12.

Instead of adding a `dfuTrigger` property inside the device structure, this approach adds another backend for the `nordic-dfu-trigger` trait/capability.

This approach makes it possible to expose the USB trait backend as a closure to some pre-open and post-open device filters. 

*Maybe* that would be a better way to expose the API of this library?

i.e. instead of the `usb` property of the constructor parameter being either a truthy or falsy value, allow for a set of filter functions. That'd keep any vendor-specific logic (including the Nordic DFU stuff) out of the backends, and have only one entry point for enumerating USB devices.