### PR TITLE
Move USB filter logic to the library consumer

### DIFF
--- a/bin/device-lister.js
+++ b/bin/device-lister.js
@@ -43,7 +43,7 @@ args
     .description('List conflated USB/serialport/jlink devices')
     .option('-u, --usb', 'Include USB devices (those available through libusb)')
     .option('-n, --nordic-usb', 'Include Nordic USB devices (with VendorID 0x1915, if available through libusb)')
-    .option('-f, --nordic-dfu', 'Include Nordic USB devices with DFU sidechannel')
+    .option('-f, --nordic-dfu', 'Include Nordic USB devices with DFU trigger')
     .option('-g, --segger-usb', 'Include Segger USB devices (with VendorID 0x1366, if available through libusb)')
     .option('-s, --serialport', 'Include serial ports (including USB CDC ACMs)')
     .option('-j, --jlink', 'Include J-link probes (those available through pc-nrfjprog-js)')
@@ -60,11 +60,41 @@ if (!args.usb && !args.nordicUsb && !args.nordicDfu && !args.seggerUsb && !args.
     console.error('Run with the --help option to see types of devices to watch for.');
 }
 
+
+if (!args.usb) {
+    let filterFns = [
+        function closedUsbDeviceFilter(){ return false } ,
+        function openUsbDeviceFilter(){ return true }
+    ];
+
+    if (args.nordicUsb) {
+        filterFns[0] = (dev)=>dev.deviceDescriptor.idVendor === 0x1915;
+    }
+
+    if (args.seggerUsb) {
+        const prevFn = filterFns[0];
+        filterFns[0] = (dev)=>(prevFn(dev) || dev.deviceDescriptor.idVendor === 0x1366);
+    }
+
+    if (args.nordicDfu) {
+        const prevFn = filterFns[0];
+        filterFns[0] = (dev)=>(prevFn(dev) || dev.deviceDescriptor.idVendor === 0x1915);
+        filterFns[1] = function(dev){
+            return dev.deviceDescriptor.idVendor === 0x1915 &&
+                dev.interfaces.some(iface => (
+                    iface.descriptor.bInterfaceClass === 255 &&
+                    iface.descriptor.bInterfaceSubClass === 1 &&
+                    iface.descriptor.bInterfaceProtocol === 1
+                )
+            );
+        };
+    }
+
+    args.usb = filterFns;
+}
+
 const lister = new DeviceLister({
     usb: args.usb,
-    nordicUsb: args.nordicUsb,
-    nordicDfu: args.nordicDfu,
-    seggerUsb: args.seggerUsb,
     serialport: args.serialport,
     jlink: args.jlink,
 });

--- a/bin/device-lister.js
+++ b/bin/device-lister.js
@@ -43,6 +43,7 @@ args
     .description('List conflated USB/serialport/jlink devices')
     .option('-u, --usb', 'Include USB devices (those available through libusb)')
     .option('-n, --nordic-usb', 'Include Nordic USB devices (with VendorID 0x1915, if available through libusb)')
+    .option('-f, --nordic-dfu', 'Include Nordic USB devices with DFU sidechannel')
     .option('-g, --segger-usb', 'Include Segger USB devices (with VendorID 0x1366, if available through libusb)')
     .option('-s, --serialport', 'Include serial ports (including USB CDC ACMs)')
     .option('-j, --jlink', 'Include J-link probes (those available through pc-nrfjprog-js)')
@@ -54,7 +55,7 @@ if (args.debug) {
     debug.enable('device-lister:*');
 }
 
-if (!args.usb && !args.nordicUsb && !args.seggerUsb && !args.serialport && !args.jlink) {
+if (!args.usb && !args.nordicUsb && !args.nordicDfu && !args.seggerUsb && !args.serialport && !args.jlink) {
     console.error('No device capabilties specified, no devices will be listed!');
     console.error('Run with the --help option to see types of devices to watch for.');
 }
@@ -62,6 +63,7 @@ if (!args.usb && !args.nordicUsb && !args.seggerUsb && !args.serialport && !args
 const lister = new DeviceLister({
     usb: args.usb,
     nordicUsb: args.nordicUsb,
+    nordicDfu: args.nordicDfu,
     seggerUsb: args.seggerUsb,
     serialport: args.serialport,
     jlink: args.jlink,

--- a/src/device-lister.js
+++ b/src/device-lister.js
@@ -33,7 +33,7 @@ import EventEmitter from 'events';
 import Usb from 'usb';
 import Debug from 'debug';
 
-import { reenumerateUsb, reenumerateSeggerUsb, reenumerateNordicUsb } from './usb-backend';
+import { reenumerateUsb, reenumerateSeggerUsb, reenumerateNordicUsb, reenumerateNordicDfuSidechannel } from './usb-backend';
 import reenumerateSerialPort from './serialport-backend';
 import reenumerateJlink from './jlink-backend';
 
@@ -51,11 +51,12 @@ export default class DeviceLister extends EventEmitter {
         this._backends = [];
 
         const {
-            usb, nordicUsb, seggerUsb, jlink, serialport,
+            usb, nordicUsb, nordicDfu, seggerUsb, jlink, serialport,
         } = capabilities;
 
         if (usb) { this._backends.push(reenumerateUsb); }
         if (nordicUsb) { this._backends.push(reenumerateNordicUsb); }
+        if (nordicDfu) { this._backends.push(reenumerateNordicDfuSidechannel); }
         if (seggerUsb) { this._backends.push(reenumerateSeggerUsb); }
         if (serialport) { this._backends.push(reenumerateSerialPort); }
         if (jlink) { this._backends.push(reenumerateJlink); }

--- a/src/device-lister.js
+++ b/src/device-lister.js
@@ -54,10 +54,7 @@ export default class DeviceLister extends EventEmitter {
             usb, nordicUsb, nordicDfu, seggerUsb, jlink, serialport,
         } = capabilities;
 
-        if (usb) { this._backends.push(reenumerateUsb); }
-        if (nordicUsb) { this._backends.push(reenumerateNordicUsb); }
-        if (nordicDfu) { this._backends.push(reenumerateNordicDfuSidechannel); }
-        if (seggerUsb) { this._backends.push(reenumerateSeggerUsb); }
+        if (usb) { this._backends.push(reenumerateUsb(usb)); }
         if (serialport) { this._backends.push(reenumerateSerialPort); }
         if (jlink) { this._backends.push(reenumerateJlink); }
 

--- a/src/usb-backend.js
+++ b/src/usb-backend.js
@@ -58,6 +58,8 @@ function hexpad4(number) {
 
 
 /*
+ * Given a filter function, and a trait name, returns a closure over a function that:
+ *
  * Given an instance of a USB device, returns *one* structure like:
  * {
  *   error: undefined
@@ -72,63 +74,74 @@ function hexpad4(number) {
  *
  * If there was an error fetching information, the serialNumber, manufacturer and
  * product fields will be empty, and the error field will contain the error.
+ *
+ * If the device didn't pass the `deviceFilter`, the closure function will return
+ * undefined instead.
  */
-function normalizeUsbDevice(usbDevice) {
-    const result = {
-        error: undefined,
-        serialNumber: undefined,
-        usb: {
+function normalizeUsbDeviceClosure(deviceFilter, traitName) {
+    return function normalizeUsbDevice(usbDevice) {
+        let result = {
+            error: undefined,
             serialNumber: undefined,
-            manufacturer: undefined,
-            product: undefined,
-            device: usbDevice,
-        },
-    };
+            [traitName]: {
+                serialNumber: undefined,
+                manufacturer: undefined,
+                product: undefined,
+                device: usbDevice,
+            },
+        };
 
-    const { busNumber, deviceAddress, deviceDescriptor } = usbDevice;
-    const {
-        iSerialNumber, iManufacturer, iProduct, idVendor, idProduct,
-    } = deviceDescriptor;
-    const debugIdStr = `${busNumber}.${deviceAddress} ${hexpad4(idVendor)}/${hexpad4(idProduct)}`;
+        const { busNumber, deviceAddress, deviceDescriptor } = usbDevice;
+        const {
+            iSerialNumber, iManufacturer, iProduct, idVendor, idProduct,
+        } = deviceDescriptor;
+        const debugIdStr = `${busNumber}.${deviceAddress} ${hexpad4(idVendor)}/${hexpad4(idProduct)}`;
 
-    return new Promise((res, rej) => {
-        try {
-            usbDevice.open();
-        } catch (ex) {
-            return rej(ex);
-        }
-        return res();
-    }).then(() => {
-        debug(`Opened: ${debugIdStr}`);
-
-        return Promise.all([
-            getStr(usbDevice, iSerialNumber),
-            getStr(usbDevice, iManufacturer),
-            getStr(usbDevice, iProduct),
-        ]);
-    }).then(([serialNumber, manufacturer, product]) => {
-        debug(`Enumerated: ${debugIdStr} `, [serialNumber, manufacturer, product]);
-        usbDevice.close();
-
-        result.serialNumber = serialNumber;
-        result.usb.serialNumber = serialNumber;
-        result.usb.manufacturer = manufacturer;
-        result.usb.product = product;
-        return result;
-    }).catch(ex => {
-        debug(`Error! ${debugIdStr}`, ex.message);
-
-        result.error = ex;
-    })
-        .then(() => {
-        // Clean up
+        return new Promise((res, rej) => {
             try {
-                usbDevice.close();
+                usbDevice.open();
             } catch (ex) {
-                debug(`Error! ${debugIdStr}`, ex.message);
+                return rej(ex);
             }
+            return res();
+        }).then(() => {
+            debug(`Opened: ${debugIdStr}`);
+
+            return Promise.all([
+                getStr(usbDevice, iSerialNumber),
+                getStr(usbDevice, iManufacturer),
+                getStr(usbDevice, iProduct),
+                deviceFilter(usbDevice),
+            ]);
+        }).then(([serialNumber, manufacturer, product, filtered]) => {
+            debug(`Enumerated: ${debugIdStr} `, [serialNumber, manufacturer, product]);
+            usbDevice.close();
+
+            if (filtered) {
+                result.serialNumber = serialNumber;
+                result[traitName].serialNumber = serialNumber;
+                result[traitName].manufacturer = manufacturer;
+                result[traitName].product = product;
+            } else {
+                debug(`Device ${debugIdStr} didn't pass the filter`);
+                result = undefined;
+            }
+            return result;
+        }).catch(ex => {
+            debug(`Error! ${debugIdStr}`, ex.message);
+
+            result.error = ex;
         })
-        .then(() => result);
+            .then(() => {
+            // Clean up
+                try {
+                    usbDevice.close();
+                } catch (ex) {
+                    debug(`Error! ${debugIdStr}`, ex.message);
+                }
+            })
+            .then(() => result);
+    };
 }
 
 /* Returns a Promise to a list of objects, like:
@@ -147,30 +160,55 @@ function normalizeUsbDevice(usbDevice) {
  * If there was an error fetching information, the serialNumber, manufacturer and
  * product fields will be empty, and the error field will contain the error.
  *
- * In the USB backend, errors are per-device.
- *
+ * In any USB backend, errors are per-device.
  */
-export function reenumerateUsb() {
-    debug('Reenumerating all USB devices...');
-    const usbDevices = Usb.getDeviceList();
-
-    return Promise.all(usbDevices.map(normalizeUsbDevice));
+function genericReenumerateUsb(
+    closedDeviceFilter = () => true, // Applies to *closed* instances of usb's Device
+    openedDeviceFilter = () => true, // Applies to *opened* instances of usb's Device
+    traitName = 'usb'
+) {
+    const usbDevices = Usb.getDeviceList().filter(closedDeviceFilter);
+    return Promise.all(usbDevices
+        .map(normalizeUsbDeviceClosure(openedDeviceFilter, traitName)))
+        .then(items => items.filter(item => item));
 }
 
+
+export function reenumerateUsb() {
+    debug('Reenumerating all USB devices...');
+    return genericReenumerateUsb(() => true, () => true, 'usb');
+}
+
+
 // Like reenumerateUsb, but cares only about USB devices with the Segger VendorId (0x1366)
+function filterSeggerVendorId(device) {
+    return device.deviceDescriptor.idVendor === SEGGER_VENDOR_ID;
+}
 export function reenumerateSeggerUsb() {
     debug('Reenumerating all Segger USB devices...');
-    const usbDevices = Usb.getDeviceList().filter(device =>
-        device.deviceDescriptor.idVendor === SEGGER_VENDOR_ID);
+    return genericReenumerateUsb(filterSeggerVendorId, () => true, 'usb');
+}
 
-    return Promise.all(usbDevices.map(normalizeUsbDevice));
+
+// Like reenumerateUsb, but cares only about USB devices with the Nordic VendorId (0x1915)
+function filterNordicVendorId(device) {
+    return device.deviceDescriptor.idVendor === NORDIC_VENDOR_ID;
+}
+export function reenumerateNordicUsb() {
+    debug('Reenumerating all Nordic USB devices...');
+    return genericReenumerateUsb(filterNordicVendorId, () => true, 'usb');
 }
 
 // Like reenumerateUsb, but cares only about USB devices with the Nordic VendorId (0x1915)
-export function reenumerateNordicUsb() {
-    debug('Reenumerating all Nordic USB devices...');
-    const usbDevices = Usb.getDeviceList().filter(device =>
-        device.deviceDescriptor.idVendor === NORDIC_VENDOR_ID);
-
-    return Promise.all(usbDevices.map(normalizeUsbDevice));
+// and a DFU sidechannel trigger interface
+function filterDfuSidechannel(device) {
+    return device.interfaces.some(iface => (
+        iface.descriptor.bInterfaceClass === 255 &&
+            iface.descriptor.bInterfaceSubClass === 1 &&
+            iface.descriptor.bInterfaceProtocol === 1
+    ));
+}
+export function reenumerateNordicDfuSidechannel() {
+    debug('Reenumerating all Nordic USB devices with DFU sidechannel trigger...');
+    return genericReenumerateUsb(filterNordicVendorId, filterDfuSidechannel, 'nordic-dfu-trigger');
 }


### PR DESCRIPTION
Like #14, but implementing the idea noted there - library consumers can specify filter functions for the `usb` trait.

I'm not really sure at this point if it's better to have the DFU trigger as its own trait, or let it be a filter of the `usb` trait.