### PR TITLE
Add util to externals in rollup.config.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,3 @@
-
 import buble from 'rollup-plugin-buble';
 import pkg from './package.json';
 
@@ -7,11 +6,18 @@ export default [
         input: pkg.module,
         output: [
             { file: pkg.main, format: 'cjs', sourcemap: true },
-//             { file: pkg.module, format: 'es', sourcemap: true }
+            // { file: pkg.module, format: 'es', sourcemap: true }
         ],
-        external: ['events', 'debug', 'usb', 'serialport', 'pc-nrfjprog-js'],
+        external: [
+            'events',
+            'util',
+            'debug',
+            'usb',
+            'serialport',
+            'pc-nrfjprog-js',
+        ],
         plugins: [
             buble({}),
-        ]
-    }
+        ],
+    },
 ];


### PR DESCRIPTION
Building failed because util was not defined as an external in the rollup config. Adding it and fixing some linting errors in the config.