### PR TITLE
Specify files to include in package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Node.js 8 or newer
 
 ## Usage as a command
 
-Do a `npm install nrf-device-lister-js` or `yarn add nrf-device-lister-js`, then run in a console:
+Do a `npm install nrf-device-lister` or `yarn add nrf-device-lister`, then run in a console:
 
 `node node_modules/.bin/nrf-device-lister --help`
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,13 @@
     "lint": "eslint src/",
     "lintfix": "eslint src/ --fix"
   },
+  "files": [
+    "bin/",
+    "src/",
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
   "dependencies": {
     "commander": "^2.14.1",
     "debug": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nrf-device-lister",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "List USB/serialport/jlink devices based on traits and conflate them by serial number",
   "module": "src/device-lister.js",
   "main": "dist/device-lister.js",


### PR DESCRIPTION
As dist/ is in .gitignore, npm will not include it when publishing to npm. Adding all the files we need in package.json to make sure they are included.