### PR TITLE
Fix retry issue when opening USB devices

### DIFF
--- a/src/device-lister.js
+++ b/src/device-lister.js
@@ -129,10 +129,12 @@ export default class DeviceLister extends EventEmitter {
 
         const pendings = this._backends.map(backend => backend.reenumerate());
 
-        return Promise.all(pendings).then(backendsResult => this._conflate(backendsResult)).catch(err => {
-            debug('Error after reenumerating: ', err);
-            this.emit('error', err);
-        });
+        return Promise.all(pendings)
+            .then(backendsResult => this._conflate(backendsResult))
+            .catch(err => {
+                debug('Error after reenumerating: ', err);
+                this.emit('error', err);
+            });
     }
 
 

--- a/src/util/usb.js
+++ b/src/util/usb.js
@@ -77,26 +77,28 @@ export function getStringDescriptors(device, indexes) {
  * @param {Object} device The usb device to open.
  * @returns {Promise} Promise that resolves if successful, rejects if failed.
  */
-export function openDevice(device, retries = 0) {
+export function openDevice(device) {
     return new Promise((res, rej) => {
-        try {
-            device.open();
-            res();
-        } catch (error) {
-            if (process.platform === 'win32' &&
-                retries < 5 &&
-                error.message === 'LIBUSB_ERROR_ACCESS') {
-                // In win platforms, the winUSB driver might allow only one
-                // process to access the USB device, potentially creating
-                // race conditions. Mitigate this with an auto-retry mechanism.
-                debug(`Got LIBUSB_ERROR_ACCESS on win32, retrying (attempt ${retries})...`);
-                setTimeout(() => {
-                    res(openDevice(device, retries + 1));
-                }, (50 * retries * retries) + (100 * Math.random()));
-            } else {
-                rej(error);
+        const tryOpen = (retries = 0) => {
+            try {
+                device.open();
+                res();
+            } catch (error) {
+                if (process.platform === 'win32' &&
+                    retries < 5 &&
+                    error.message === 'LIBUSB_ERROR_ACCESS') {
+                    // In win platforms, the winUSB driver might allow only one
+                    // process to access the USB device, potentially creating
+                    // race conditions. Mitigate this with an auto-retry mechanism.
+                    debug(`Got LIBUSB_ERROR_ACCESS on win32, retrying (attempt ${retries})...`);
+                    const delay = (50 * retries * retries) + (100 * Math.random());
+                    setTimeout(() => tryOpen(retries + 1), delay);
+                } else {
+                    rej(error);
+                }
             }
-        }
+        };
+        tryOpen();
     });
 }
 

--- a/src/util/usb.js
+++ b/src/util/usb.js
@@ -81,6 +81,7 @@ export function openDevice(device, retries = 0) {
     return new Promise((res, rej) => {
         try {
             device.open();
+            res();
         } catch (error) {
             if (process.platform === 'win32' &&
                 retries < 5 &&
@@ -93,10 +94,9 @@ export function openDevice(device, retries = 0) {
                     res(openDevice(device, retries + 1));
                 }, (50 * retries * retries) + (100 * Math.random()));
             } else {
-                return rej(error);
+                rej(error);
             }
         }
-        return res();
     });
 }
 


### PR DESCRIPTION
I found a problem when testing on Windows with multiple device listers running in separate processes. When inserting a USB device, the device showed up in one of the processes, but not the other. It turned out that when getting a `LIBUSB_ERROR_ACCESS` error in `openDevice()`, the retry mechanism never kicked in, and the promise was just resolved.

Made some changes to fix this. See commit messages for details.