### PR TITLE
Normalize on string type for serial numbers.

### DIFF
--- a/src/device-lister.js
+++ b/src/device-lister.js
@@ -180,12 +180,7 @@ export default class DeviceLister extends EventEmitter {
         backendsResult.forEach(results => {
             results.forEach(result => {
                 if (result.serialNumber) {
-                    let { serialNumber } = result;
-                    // If the serial number is fully numeric (not a hex string),
-                    // cast it into an integer
-                    if (typeof serialNumber === 'string' && serialNumber.match(/^\d+$/)) {
-                        serialNumber = Number(serialNumber);
-                    }
+                    const { serialNumber } = result;
 
                     let device = deviceMap.get(serialNumber) || {};
                     const { traits } = device;

--- a/src/jlink-backend.js
+++ b/src/jlink-backend.js
@@ -68,7 +68,12 @@ export default class JlinkBackend extends AbstractBackend {
         }).then(serialnumbers => serialnumbers.map(serialnumber => {
             debug('Enumerated:', serialnumber);
             return {
-                serialNumber: serialnumber,
+                // The nrfjprogjs provides the serial numbers as integers, what we want
+                // is the serial number as described in the USB descriptor (iSerialNumber).
+                // The USB descriptor iSerialNumber attribute is of type string.
+                //
+                // Pad the serial number with '0' with the assumed serial number length of 12
+                serialNumber: serialnumber.toString().padStart(12, '0'),
                 traits: ['jlink'],
             };
         })).catch(err => {


### PR DESCRIPTION
Normalize on string type for device serial numbers so that users do not have to take into account different values types using our API's.

Note:
https://github.com/NordicSemiconductor/nrf-device-setup-js also needs to be updated to support this.

I'm not sure what policy to apply for bumping the version number for this package; it does change the  value type returned.