### PR TITLE
Bumping to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nrf-device-lister",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "List USB/serialport/jlink devices based on traits and conflate them by serial number",
   "module": "src/device-lister.js",
   "main": "dist/device-lister.js",


### PR DESCRIPTION
The serial number is now a string instead of a number. This is a breaking change, and we are following semver, so bumping the major version is needed.