### PR TITLE
Version 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debug": "^3.1.0",
     "serialport": "^6.2.0",
     "pc-nrfjprog-js": "^1.4.4",
-    "usb": "github:NordicPlayground/node-usb#1.5.0"
+    "usb": "git+https://github.com/NordicPlayground/node-usb.git#semver:^1.5.0"
   },
   "devDependencies": {
     "eslint": "^4.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nrf-device-lister",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "List USB/serialport/jlink devices based on traits and conflate them by serial number",
   "module": "src/device-lister.js",
   "main": "dist/device-lister.js",


### PR DESCRIPTION
The previous usb module reference did refer to Nordic's repo, but npm still tried to pull binaries from upstream. This is fixed now.