### PR TITLE
Add arguments to list comPort or serialNumber by board type

### DIFF
--- a/bin/device-lister.js
+++ b/bin/device-lister.js
@@ -33,7 +33,7 @@
 
 'use strict';
 
-const DeviceLister = require('../');
+const DeviceLister = require('../src/device-lister');
 const { version } = require('../package.json');
 const args = require('commander');
 const debug = require('debug');

--- a/bin/device-lister.js
+++ b/bin/device-lister.js
@@ -53,6 +53,8 @@ args
     .option('-w, --watch', 'Keep outputting a list of devices on any changes')
     .option('-d, --debug', 'Enable debug messages')
     .option('-e, --error', 'Enable error messages')
+    .option('-p, --ports-by-board [board]', 'List serialports by PCA board id')
+    .option('-S, --serialnumbers-by-board [board]', 'List serial numbers by PCA board id')
     .parse(process.argv);
 
 if (args.debug) {
@@ -63,6 +65,15 @@ if (!args.usb && !args.nordicUsb && !args.nordicDfu && !args.seggerUsb &&
     !args.serialport && !args.jlink && args.error) {
     console.error('No device traits specified, no devices will be listed!');
     console.error('Run with the --help option to see types of devices to watch for.');
+}
+
+if (args.listAll || args.listAllInfo || args.portsByBoard || args.serialnumbersByBoard) {
+    args.nordicUsb = true;
+    args.serialport = true;
+    args.seggerUsb = true;
+    args.nordicUsb = true;
+    args.nordicDfu = true;
+    args.jlink = true;
 }
 
 const lister = new DeviceLister({
@@ -137,5 +148,29 @@ if (args.listAllInfo) {
             });
         });
         console.log(JSON.stringify(result, null, 2));
+    });
+}
+
+if (args.portsByBoard) {
+    lister.reenumerate().then(devices => {
+        const result = [];
+        devices.forEach(d => {
+            if (d.boardVersion === args.portsByBoard) {
+                result.push(d.serialport.comName);
+            }
+        });
+        console.log(result.join(' '));
+    });
+}
+
+if (args.serialnumbersByBoard) {
+    lister.reenumerate().then(devices => {
+        const result = [];
+        devices.forEach(d => {
+            if (d.boardVersion === args.serialnumbersByBoard) {
+                result.push(d.serialNumber);
+            }
+        });
+        console.log(result.join(' '));
     });
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "rollup": "rollup -c rollup.config.js",
     "lint": "eslint src/ bin/",
     "lintfix": "eslint src/ bin/ --fix",
-    "test": "rollup -c rollup.config.js && DEBUG=device-lister:test jest --detectOpenHandles --runInBand"
+    "test": "rollup -c rollup.config.js && jest --detectOpenHandles --runInBand"
   },
   "files": [
     "bin/",
@@ -35,8 +35,8 @@
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0",
     "rollup": "^0.56.4",
-    "rollup-plugin-buble": "^0.18.0",
     "rollup-plugin-eslint": "^4.0.0",
+    "rollup-plugin-commonjs": "^9.2.3",
     "jest": "^23.6.0"
   },
   "jest": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-import buble from 'rollup-plugin-buble';
+import commonjs from 'rollup-plugin-commonjs';
 import pkg from './package.json';
 
 export default [
@@ -18,7 +18,7 @@ export default [
             'pc-nrfjprog-js',
         ],
         plugins: [
-            buble({}),
+            commonjs({}),
         ],
     },
 ];

--- a/src/abstract-backend.js
+++ b/src/abstract-backend.js
@@ -29,9 +29,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import ErrorCodes from './util/errors';
+const ErrorCodes = require('./util/errors');
 
-export default class AbstractBackend {
+class AbstractBackend {
     constructor() {
         if (this.constructor === AbstractBackend) {
             const err = new Error('Cannot instantiate AbstractBackend.');
@@ -80,3 +80,5 @@ export default class AbstractBackend {
         throw err;
     }
 }
+
+module.exports = AbstractBackend;

--- a/src/device-lister.js
+++ b/src/device-lister.js
@@ -29,21 +29,21 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import EventEmitter from 'events';
-import Usb from 'usb';
-import Debug from 'debug';
-import UsbBackend from './usb-backend';
-import SerialPortBackend from './serialport-backend';
-import JlinkBackend from './jlink-backend';
-import ErrorCodes from './util/errors';
-import { getBoardVersion } from './util/board-versions';
+const EventEmitter = require('events');
+const Usb = require('usb');
+const Debug = require('debug');
+const UsbBackend = require('./usb-backend');
+const SerialPortBackend = require('./serialport-backend');
+const JlinkBackend = require('./jlink-backend');
+const ErrorCodes = require('./util/errors');
+const { getBoardVersion } = require('./util/board-versions');
 
 const debug = Debug('device-lister:conflater');
 
 const SEGGER_VENDOR_ID = 0x1366;
 const NORDIC_VENDOR_ID = 0x1915;
 
-export default class DeviceLister extends EventEmitter {
+class DeviceLister extends EventEmitter {
     constructor(traits = {}) {
         super();
 
@@ -227,3 +227,5 @@ export default class DeviceLister extends EventEmitter {
 }
 DeviceLister.ErrorCodes = ErrorCodes;
 DeviceLister.getBoardVersion = getBoardVersion;
+
+module.exports = DeviceLister;

--- a/src/jlink-backend.js
+++ b/src/jlink-backend.js
@@ -29,15 +29,15 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import nrfjprogjs from 'pc-nrfjprog-js';
-import Debug from 'debug';
-import AbstractBackend from './abstract-backend';
-import ErrorCodes from './util/errors';
-import { getBoardVersion } from './util/board-versions';
+const nrfjprogjs = require('pc-nrfjprog-js');
+const Debug = require('debug');
+const AbstractBackend = require('./abstract-backend');
+const ErrorCodes = require('./util/errors');
+const { getBoardVersion } = require('./util/board-versions');
 
 const debug = Debug('device-lister:jlink');
 
-export default class JlinkBackend extends AbstractBackend {
+class JlinkBackend extends AbstractBackend {
     /* Returns a `Promise` to a list of objects, like:
      *
      * [{
@@ -90,3 +90,5 @@ export default class JlinkBackend extends AbstractBackend {
         });
     }
 }
+
+module.exports = JlinkBackend;

--- a/src/serialport-backend.js
+++ b/src/serialport-backend.js
@@ -29,11 +29,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import SerialPort from 'serialport';
-import Debug from 'debug';
-import AbstractBackend from './abstract-backend';
-import ErrorCodes from './util/errors';
-import { getBoardVersion } from './util/board-versions';
+const SerialPort = require('serialport');
+const Debug = require('debug');
+const AbstractBackend = require('./abstract-backend');
+const ErrorCodes = require('./util/errors');
+const { getBoardVersion } = require('./util/board-versions');
 
 const debug = Debug('device-lister:serialport');
 
@@ -50,7 +50,7 @@ function getSerialPorts() {
     });
 }
 
-export default class SerialPortBackend extends AbstractBackend {
+class SerialPortBackend extends AbstractBackend {
     /* Returns a Promise to a list of objects, like:
      *
      * [{
@@ -108,3 +108,5 @@ export default class SerialPortBackend extends AbstractBackend {
             });
     }
 }
+
+module.exports = SerialPortBackend;

--- a/src/usb-backend.js
+++ b/src/usb-backend.js
@@ -29,12 +29,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Usb from 'usb';
-import Debug from 'debug';
-import { Mutex } from 'await-semaphore';
-import AbstractBackend from './abstract-backend';
-import { getStringDescriptors, openDevice, getDeviceId } from './util/usb';
-import ErrorCodes from './util/errors';
+const Usb = require('usb');
+const Debug = require('debug');
+const { Mutex } = require('await-semaphore');
+const AbstractBackend = require('./abstract-backend');
+const { getStringDescriptors, openDevice, getDeviceId } = require('./util/usb');
+const ErrorCodes = require('./util/errors');
 
 const debug = Debug('device-lister:usb');
 
@@ -138,7 +138,7 @@ function decorateError(err) {
 /**
  * Backend that enumerates usb devices.
  */
-export default class UsbBackend extends AbstractBackend {
+class UsbBackend extends AbstractBackend {
     /*
      * The constructor takes in two sets of filters. These must be objects,
      * with strings as keys and functions as values. These functions must
@@ -287,3 +287,5 @@ export default class UsbBackend extends AbstractBackend {
         Usb.removeListener('detach', this._boundRemoveCachedResult);
     }
 }
+
+module.exports = UsbBackend;

--- a/src/util/board-versions.js
+++ b/src/util/board-versions.js
@@ -1,4 +1,4 @@
-export const BoardVersion = {
+const BoardVersion = {
     680: 'PCA10031',
     681: 'PCA10028',
     682: 'PCA10040',
@@ -8,8 +8,13 @@ export const BoardVersion = {
     960: 'PCA10090',
 };
 
-export const getBoardVersion = serialNumber => {
+const getBoardVersion = serialNumber => {
     const sn = parseInt(serialNumber, 10).toString();
     const digits = sn.substring(0, 3);
     return BoardVersion[digits];
+};
+
+module.exports = {
+    BoardVersion,
+    getBoardVersion,
 };

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -1,4 +1,4 @@
-export default Object.freeze({
+module.exports = Object.freeze({
     CANNOT_INSTANTIATE_ABSTRACTBACKEND: 0,
     REENUMERATE_NOT_IMPLEMENTED: 1,
     RECEIVED_NEITHER_SNO_NOR_ERROR: 2,

--- a/src/util/usb.js
+++ b/src/util/usb.js
@@ -29,7 +29,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Debug from 'debug';
+const Debug = require('debug');
 
 const debug = Debug('device-lister:usb');
 
@@ -62,7 +62,7 @@ function getStringDescriptor(device, index) {
  * @param {Array<number>} indexes The indexes to get.
  * @returns {Promise} Promise that resolves with array of string descriptors.
  */
-export function getStringDescriptors(device, indexes) {
+function getStringDescriptors(device, indexes) {
     return indexes.reduce((prev, index) => (
         prev.then(descriptorValues => (
             getStringDescriptor(device, index)
@@ -77,7 +77,7 @@ export function getStringDescriptors(device, indexes) {
  * @param {Object} device The usb device to open.
  * @returns {Promise} Promise that resolves if successful, rejects if failed.
  */
-export function openDevice(device) {
+function openDevice(device) {
     return new Promise((res, rej) => {
         const tryOpen = (retries = 0) => {
             try {
@@ -108,7 +108,7 @@ export function openDevice(device) {
  * @param {Number} number The number to prefix and pad.
  * @returns {string} Prefixed and padded number.
  */
-export function hexpad4(number) {
+function hexpad4(number) {
     return `0x${number.toString(16).padStart(4, '0')}`;
 }
 
@@ -119,8 +119,15 @@ export function hexpad4(number) {
  * @param {Object} device The device to get an ID for.
  * @returns {string} String ID for the given device.
  */
-export function getDeviceId(device) {
+function getDeviceId(device) {
     const { busNumber, deviceAddress } = device;
     const { idVendor, idProduct } = device.deviceDescriptor;
     return `${busNumber}.${deviceAddress} ${hexpad4(idVendor)}/${hexpad4(idProduct)}`;
 }
+
+module.exports = {
+    getStringDescriptors,
+    openDevice,
+    hexpad4,
+    getDeviceId,
+};


### PR DESCRIPTION
This PR adds 2 new functions to the utility and also eliminates the need to rollup by using require instead of es6 imports.