### PR TITLE
Fix/thingy support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nrf-device-lister",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "List USB/serialport/jlink devices based on traits and conflate them by serial number",
   "module": "src/device-lister.js",
   "main": "dist/device-lister.js",

--- a/src/device-lister.js
+++ b/src/device-lister.js
@@ -42,6 +42,7 @@ const debug = Debug('device-lister:conflater');
 
 const SEGGER_VENDOR_ID = 0x1366;
 const NORDIC_VENDOR_ID = 0x1915;
+const NORDIC_DEVICE_WITH_DFU_TRIGGER = 0xC00A;
 
 class DeviceLister extends EventEmitter {
     constructor(traits = {}) {
@@ -70,6 +71,7 @@ class DeviceLister extends EventEmitter {
         if (nordicUsb) {
             usbDeviceClosedFilters.nordicUsb = device => (
                 device.deviceDescriptor.idVendor === NORDIC_VENDOR_ID
+                && device.deviceDescriptor.idProduct === NORDIC_DEVICE_WITH_DFU_TRIGGER
             );
         }
         if (seggerUsb) {

--- a/src/device-lister.js
+++ b/src/device-lister.js
@@ -78,17 +78,18 @@ class DeviceLister extends EventEmitter {
             );
         }
         if (nordicDfu) {
-            usbDeviceOpenFilters.nordicDfu = device =>
-                device.deviceDescriptor.idVendor === NORDIC_VENDOR_ID &&
-                device.interfaces.some(iface => (
-                    iface.descriptor.bInterfaceClass === 255 &&
-                    iface.descriptor.bInterfaceSubClass === 1 &&
-                    iface.descriptor.bInterfaceProtocol === 1
-                ));
+            usbDeviceOpenFilters.nordicDfu = device => (
+                device.deviceDescriptor.idVendor === NORDIC_VENDOR_ID
+                && device.interfaces.some(iface => (
+                    iface.descriptor.bInterfaceClass === 255
+                    && iface.descriptor.bInterfaceSubClass === 1
+                    && iface.descriptor.bInterfaceProtocol === 1
+                ))
+            );
         }
 
-        if (Object.keys(usbDeviceClosedFilters).length > 0 ||
-            Object.keys(usbDeviceOpenFilters).length > 0) {
+        if (Object.keys(usbDeviceClosedFilters).length > 0
+            || Object.keys(usbDeviceOpenFilters).length > 0) {
             this._backends.push(new UsbBackend(usbDeviceClosedFilters, usbDeviceOpenFilters));
         }
         if (serialport) { this._backends.push(new SerialPortBackend()); }

--- a/src/usb-backend.js
+++ b/src/usb-backend.js
@@ -61,80 +61,6 @@ function getMatchingDeviceFilters(device, filters) {
     }).filter(filterName => filterName);
 }
 
-
-/**
- * Given a libusb error, this function assigns the error argument an error code
- * representing the error type.
- *
- * @param {Object} err The error to assign an error code to.
- * @returns {Object} The error with a code assigned, given it is a libusb error.
-*/
-function decorateError(err) {
-    const error = err;
-    switch (error.message) {
-        case 'LIBUSB_SUCCESS': {
-            error.errorCode = ErrorCodes.LIBUSB_SUCCESS;
-            break;
-        }
-        case 'LIBUSB_ERROR_IO': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_IO;
-            break;
-        }
-        case 'LIBUSB_ERROR_INVALID_PARAM': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_INVALID_PARAM;
-            break;
-        }
-        case 'LIBUSB_ERROR_ACCESS': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_ACCESS;
-            break;
-        }
-        case 'LIBUSB_ERROR_NO_DEVICE': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_NO_DEVICE;
-            break;
-        }
-        case 'LIBUSB_ERROR_NOT_FOUND': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_NOT_FOUND;
-            break;
-        }
-        case 'LIBUSB_ERROR_BUSY': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_BUSY;
-            break;
-        }
-        case 'LIBUSB_ERROR_TIMEOUT': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_TIMEOUT;
-            break;
-        }
-        case 'LIBUSB_ERROR_OVERFLOW': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_OVERFLOW;
-            break;
-        }
-        case 'LIBUSB_ERROR_PIPE': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_PIPE;
-            break;
-        }
-        case 'LIBUSB_ERROR_INTERRUPTED': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_INTERRUPTED;
-            break;
-        }
-        case 'LIBUSB_ERROR_NO_MEM': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_NO_MEM;
-            break;
-        }
-        case 'LIBUSB_ERROR_NOT_SUPPORTED': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_NOT_SUPPORTED;
-            break;
-        }
-        case 'LIBUSB_ERROR_OTHER': {
-            error.errorCode = ErrorCodes.LIBUSB_ERROR_OTHER;
-            break;
-        }
-        default: {
-            break;
-        }
-    }
-    return error;
-}
-
 /**
  * Backend that enumerates usb devices.
  */
@@ -222,10 +148,8 @@ class UsbBackend extends AbstractBackend {
                     });
                 }).catch(error => {
                     debug('Error when reading device:', deviceId, error.message);
-                    const err = decorateError(error);
-                    err.usb = device;
                     result = {
-                        error: err,
+                        error: { ...error, errorCode: ErrorCodes[error.message], usb: device },
                         errorSource: deviceId,
                     };
                 }).then(() => {
@@ -235,10 +159,10 @@ class UsbBackend extends AbstractBackend {
                     } catch (error) {
                         debug('Error when closing device:', deviceId, error.message);
                         if (!result.error) {
-                            const err = decorateError(error);
-                            err.usb = device;
                             result = {
-                                error: err,
+                                error: {
+                                    ...error, errorCode: ErrorCodes[error.message], usb: device,
+                                },
                                 errorSource: deviceId,
                             };
                         }

--- a/src/util/board-versions.js
+++ b/src/util/board-versions.js
@@ -9,6 +9,9 @@ const BoardVersion = {
 };
 
 const getBoardVersion = serialNumber => {
+    if (serialNumber.toString().startsWith('PCA')) {
+        return serialNumber.toString().split('_')[0];
+    }
     const sn = parseInt(serialNumber, 10).toString();
     const digits = sn.substring(0, 3);
     return BoardVersion[digits];

--- a/test/lister.test.js
+++ b/test/lister.test.js
@@ -37,8 +37,8 @@
 'use strict';
 
 const path = require('path');
-const DeviceLister = require('../dist/device-lister');
 const nrfjprog = require('pc-nrfjprog-js');
+const DeviceLister = require('../dist/device-lister');
 
 const { getBoardVersion } = DeviceLister;
 


### PR DESCRIPTION
This PR modifies the device filters such that only device with dfu trigger interface is regarded as nordicUsb, otherwise it such device will cause LIBUSB issues with multiple apps.

- only 1915:c00a devices will be treated as nordicUsb
- added boardVersion support to Thingy:91
- fixed linting issues
- simplified code