### PR TITLE
Upgrade serialport

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var lister = new DeviceLister({
 });
 
 
-// When started, the lister will emit three kinds of events:
+// When started, the lister will two three kinds of events:
 
 // The 'conflated' event fires whenever there is a new conflated list of
 // devices (i.e. after each reenumeration). This list is an instance of Map,

--- a/bin/device-lister.js
+++ b/bin/device-lister.js
@@ -33,10 +33,10 @@
 
 'use strict';
 
-const DeviceLister = require('../src/device-lister');
-const { version } = require('../package.json');
 const args = require('commander');
 const debug = require('debug');
+const DeviceLister = require('../src/device-lister');
+const { version } = require('../package.json');
 
 args
     .version(version)
@@ -61,8 +61,14 @@ if (args.debug) {
     debug.enable('device-lister:*');
 }
 
-if (!args.usb && !args.nordicUsb && !args.nordicDfu && !args.seggerUsb &&
-    !args.serialport && !args.jlink && args.error) {
+if (!args.usb
+    && !args.nordicUsb
+    && !args.nordicDfu
+    && !args.seggerUsb
+    && !args.serialport
+    && !args.jlink
+    && args.error
+) {
     console.error('No device traits specified, no devices will be listed!');
     console.error('Run with the --help option to see types of devices to watch for.');
 }

--- a/bin/device-lister.js
+++ b/bin/device-lister.js
@@ -95,7 +95,7 @@ lister.on('error', error => {
             error.usb.deviceDescriptor.idProduct.toString(16).padStart(4, '0')}: ${
             error.message}`);
     } else if (error.serialport) {
-        console.error(`Error from a serial port at ${error.serialport.comName}: `, error.message);
+        console.error(`Error from a serial port at ${error.serialport.path}: `, error.message);
     } else {
         console.error(error);
     }
@@ -156,7 +156,7 @@ if (args.portsByBoard) {
         const result = [];
         devices.forEach(d => {
             if (d.boardVersion === args.portsByBoard) {
-                result.push(d.serialport.comName);
+                result.push(d.serialport.path);
             }
         });
         console.log(result.join(' '));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nrf-device-lister",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "List USB/serialport/jlink devices based on traits and conflate them by serial number",
   "module": "src/device-lister.js",
   "main": "dist/device-lister.js",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "await-semaphore": "^0.1.3",
     "commander": "^2.20.0",
     "debug": "^4.1.1",
-    "serialport": "^7.1.5",
     "pc-nrfjprog-js": "^1.6.0",
+    "serialport": "^8.0.7",
     "usb": "^1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Part of [NCP-2996](https://projecttools.nordicsemi.no/jira/browse/NCP-2996).

Upgrade serialport dependency to the latest version 8.0.7.

The new version has renamed the property `comName` to `path` and removed the callback from `SerialPort.list()`.

If other code using this package still tries to access the property `comName` the right value will be returned but a warning will also be printed, that this is deprecated and will be removed in the future.

If other code using this package still accesses the serial port package directly and uses [the outdated API](https://github.com/serialport/node-serialport/blob/master/UPGRADE_GUIDE.md), it of course still has to be updated.


