### PR TITLE
Add PIDs of known Nordic devices

### DIFF
--- a/src/device-lister.js
+++ b/src/device-lister.js
@@ -42,7 +42,7 @@ const debug = Debug('device-lister:conflater');
 
 const SEGGER_VENDOR_ID = 0x1366;
 const NORDIC_VENDOR_ID = 0x1915;
-const NORDIC_DEVICE_WITH_DFU_TRIGGER = 0xC00A;
+const NORDIC_PID = [0x521f, 0xc00a, 0xcafe, 0x154a];
 
 class DeviceLister extends EventEmitter {
     constructor(traits = {}) {
@@ -71,7 +71,7 @@ class DeviceLister extends EventEmitter {
         if (nordicUsb) {
             usbDeviceClosedFilters.nordicUsb = device => (
                 device.deviceDescriptor.idVendor === NORDIC_VENDOR_ID
-                && device.deviceDescriptor.idProduct === NORDIC_DEVICE_WITH_DFU_TRIGGER
+                && NORDIC_PID.includes(device.deviceDescriptor.idProduct)
             );
         }
         if (seggerUsb) {


### PR DESCRIPTION
This adds PIDs of known Nordic devices:

- 0x521f USB Boootloader
- 0xcafe OpenThread samples
- 0x154a IEEE802.15.4 sniffer

Signed-off-by: Piotr Szkotak <piotr.szkotak@nordicsemi.no>